### PR TITLE
Allow strings like "17.4 million"

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,13 @@ function convert(obj) {
 
     partial[cls] = 0;
 
+    // handle numeric values
+    if(vAmount.match(/^[0-9.]+$/))
+    {
+        partial[cls] += parseFloat(vAmount);
+        continue;
+    }
+
     // handle hundrers in MSBs
     var split = _processClassifier(vAmount, classifiers[0]);
     if (split) {


### PR DESCRIPTION
Simple addition that allows strings that are partially numeric, partially words, like people commonly type.
