### PR TITLE
Allow numeric portions of strings, like "17.46 million"

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,10 +149,9 @@ function convert(obj) {
     partial[cls] = 0;
 
     // handle numeric values
-    if(vAmount.match(/^[0-9.]+$/))
-    {
-        partial[cls] += parseFloat(vAmount);
-        continue;
+    if(vAmount.match(/^[0-9.]+$/)) {
+      partial[cls] += parseFloat(vAmount);
+      continue;
     }
 
     // handle hundrers in MSBs

--- a/index.js
+++ b/index.js
@@ -14,17 +14,17 @@ var classifiers = [
   },
   {
     id: 'thousands',
-    forms: ['thousands', 'thousand'],
+    forms: ['thousands', 'thousand', 'k', 'K'],
     multiplier: 1e3
   },
   {
     id: 'millions',
-    forms: ['millions', 'million'],
+    forms: ['millions', 'million', 'M', 'mln'],
     multiplier: 1e6
   },
   {
     id: 'billions',
-    forms: ['billions', 'billion'],
+    forms: ['billions', 'billion', 'G', 'B', 'bln'],
     multiplier: 1e9
   }
 ];

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function convert(obj) {
     partial[cls] = 0;
 
     // handle numeric values
-    if(vAmount.match(/^[0-9.]+$/)) {
+    if (vAmount.match(/^[0-9.]+$/)) {
       partial[cls] += parseFloat(vAmount);
       continue;
     }

--- a/index.js
+++ b/index.js
@@ -148,6 +148,13 @@ function convert(obj) {
 
     partial[cls] = 0;
 
+    // handle numeric values
+    if(vAmount.match(/^[0-9.]+$/))
+    {
+        partial[cls] += parseFloat(vAmount);
+        continue;
+    }
+
     // handle hundrers in MSBs
     var split = _processClassifier(vAmount, classifiers[0]);
     if (split) {

--- a/test/convert.js
+++ b/test/convert.js
@@ -45,9 +45,9 @@ var data = [
 
   {
     input: {
-        billions: '17',
-        hundreds: '12',
-        units: '7'
+      billions: '17',
+      hundreds: '12',
+      units: '7'
     },
     expect: 17000001207
   }

--- a/test/convert.js
+++ b/test/convert.js
@@ -41,6 +41,15 @@ var data = [
       billions: 'one hundred and thirty five'
     },
     expect: 135000000000
+  },
+
+  {
+    input: {
+        billions: '17',
+        hundreds: '12',
+        units: '7'
+    },
+    expect: 17000001207
   }
 ];
 

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,11 @@ var data = [
   {
     input: 'nine millions three hundreds sixty five thousands three hundreds eleven',
     expect: 9365311
+  },
+
+  {
+    input: '17.46 million',
+    expect: 17460000
   }
 ];
 

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,24 @@ var data = [
   {
     input: '17.46 million',
     expect: 17460000
+  },
+
+  {
+    input: '.43B',
+    expect: 430000000
+  },
+
+  {
+    input: '12.5k',
+    expect: 12500
+  },
+
+  {
+    input: '13 bln',
+    expect: 13000000000
   }
+
+
 ];
 
 describe('translate string', function() {


### PR DESCRIPTION
Simple addition that allows strings that are partially numeric, partially words, like people commonly type.
